### PR TITLE
Add Porcuna weather endpoint and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Documentación adicional
+
+Se incluyen archivos en el directorio `docs/` con información sobre el proyecto y un nuevo endpoint de la API del tiempo para Porcuna.

--- a/app/Http/Controllers/WeatherController.php
+++ b/app/Http/Controllers/WeatherController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Http;
+
+class WeatherController extends Controller
+{
+    /**
+     * Devuelve la información meteorológica de Porcuna en formato JSON.
+     */
+    public function porcuna()
+    {
+        $response = Http::get('https://wttr.in/Porcuna?format=j1');
+
+        if ($response->successful()) {
+            return $response->json();
+        }
+
+        return response()->json([
+            'error' => 'Unable to fetch weather data'
+        ], $response->status());
+    }
+}

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,0 +1,11 @@
+# Información General
+
+Este proyecto es un ejemplo construido con Laravel 11. Incluye un sistema de tickets y una vista para consultar el tiempo. Las rutas principales están definidas en `routes/web.php`.
+
+## Componentes destacados
+
+- **Tickets**: Permite crear y gestionar tickets por departamento.
+- **PDF**: Genera documentos PDF con Dompdf.
+- **Weather**: Consulta el tiempo utilizando la API de wttr.in.
+
+Consulta `docs/WEATHER_API.md` para conocer el nuevo endpoint de Porcuna.

--- a/docs/WEATHER_API.md
+++ b/docs/WEATHER_API.md
@@ -1,0 +1,26 @@
+# Weather API
+
+Esta aplicación incluye un controlador para consultar el tiempo en distintas ciudades.
+
+## Endpoint de Porcuna
+
+```
+GET /api/weather/porcuna
+```
+
+Devuelve un objeto JSON con la información meteorológica obtenida desde wttr.in.
+
+### Ejemplo de respuesta
+
+```json
+{
+  "current_condition": [
+    {
+      "temp_C": "20",
+      "weatherDesc": [{"value": "Partly cloudy"}]
+    }
+  ]
+}
+```
+
+Para probarlo en local, levanta el servidor de Laravel y visita `http://localhost:8000/api/weather/porcuna`.

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\PDFController;
 use App\Http\Controllers\TicketController;
+use App\Http\Controllers\WeatherController;
 use Illuminate\Support\Facades\Route;
 
 // Ruta principal - Aplicación del Tiempo
@@ -22,3 +23,6 @@ Route::prefix('tickets')->group(function () {
 
 // Ruta para generar PDF
 Route::get('generate-pdf', [PDFController::class, 'generatePDF'])->name('generate.pdf');
+
+// API del tiempo
+Route::get('api/weather/porcuna', [WeatherController::class, 'porcuna'])->name('weather.porcuna');


### PR DESCRIPTION
## Summary
- document project overview and weather API
- create `WeatherController` for Porcuna
- expose `/api/weather/porcuna` route
- mention docs in main README

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe68a4448832db16765602d70383c